### PR TITLE
Add missing oauth2client dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
             'google-api-python-client>=1.6.5',
             'httplib2>=0.10.3',
             'taskw==1.2.0',
+            'oauth2client==4.1.3',
         ],
 
         tests_require=[


### PR DESCRIPTION
Includes `oauth2client` as dependency, latest as reported by [oauth2client/releases](https://github.com/googleapis/oauth2client/releases) page.

Fixes #8 
